### PR TITLE
added support for downloading srt files

### DIFF
--- a/xbmc/xbmcgui.go
+++ b/xbmc/xbmcgui.go
@@ -186,6 +186,10 @@ func PlayerIsPaused() bool {
 	return retVal != 0
 }
 
+func PlayerSetSubtitles(url string) {
+	executeJSONRPCEx("Player_SetSubtitles", nil, Args{url})
+}
+
 func GetWatchTimes() map[string]string {
 	var retVal map[string]string
 	executeJSONRPCEx("Player_WatchTimes", &retVal, nil)


### PR DESCRIPTION
Change for enabling in-place srt files.

How:
- After file is chosen - checking for .srt files in same torrent;
- Setting priorities
- When file is played with /files/* torrentfs opener - we check for an srt in torrent and call setSubtitles().