### PR TITLE
added alternate matcher for episode file

### DIFF
--- a/bittorrent/player.go
+++ b/bittorrent/player.go
@@ -589,7 +589,7 @@ func (btp *BTPlayer) chooseFile() (int, error) {
 			var foundMatches int
 			// Case-insensitive, starting with a line-start or non-ascii, can have leading zeros, followed by non-ascii
 			// TODO: Add logic for matching S01E0102 (double episode filename)
-			re := regexp.MustCompile(fmt.Sprintf("(?i)(^|\\W)S0*?%dE0*?%d\\W", btp.season, btp.episode))
+			re := regexp.MustCompile(fmt.Sprintf("(?i)(^|\\W)(S0*?%dE0*?%d|%dx0*?%d)\\W", btp.season, btp.episode, btp.season, btp.episode))
 			for index, choice := range choices {
 				if re.MatchString(choice.Filename) {
 					lastMatched = index


### PR DESCRIPTION
Currently only "S{season}E{episode}" is matched automatically. 
This change adds match for "{season}x{episode}".