### PR TITLE
added check for non-initialized configuration in Kodi.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -191,6 +191,15 @@ func Reload() *Configuration {
 		}
 	}
 
+	defer func() {
+		if r := recover(); r != nil {
+			log.Debug("Addon settings not properly set, opening settings window")
+			xbmc.Dialog("Quasar", "LOCALIZE[30309]")
+			xbmc.AddonSettings("plugin.video.quasar")
+			os.Exit(0)
+	 	}
+	}()
+
 	newConfig := Configuration{
 		DownloadPath:        downloadPath,
 		LibraryPath:         libraryPath,


### PR DESCRIPTION
When configuration has missing setting (for example after upgrade with new settings being added), Quasar logs a panic and quietly closes.
This change is catching it, showing a dialog, then opening a settings window.