### PR TITLE
New categories under Trakt: My Shows and My Next Episodes && Mark watched episodes and movies in Trakt

### DIFF
--- a/api/cmd.go
+++ b/api/cmd.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/op/go-logging"
+	logging "github.com/op/go-logging"
 	"github.com/scakemyer/quasar/cloudhole"
 	"github.com/scakemyer/quasar/config"
 	"github.com/scakemyer/quasar/xbmc"
@@ -30,7 +30,7 @@ func SetViewMode(ctx *gin.Context) {
 	viewMode := xbmc.GetCurrentView()
 	cmdLog.Noticef("ViewMode: %s (%s)", viewName, viewMode)
 	if viewMode != "0" {
-		xbmc.SetSetting("viewmode_" + content_type, viewMode)
+		xbmc.SetSetting("viewmode_"+content_type, viewMode)
 	}
 	ctx.String(200, "")
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -141,6 +141,7 @@ func Routes(btService *bittorrent.BTService) *gin.Engine {
 			trakt.GET("/watched", cache.Cache(store, DefaultCacheExpiration), TraktMostWatchedShows)
 			trakt.GET("/collected", cache.Cache(store, DefaultCacheExpiration), TraktMostCollectedShows)
 			trakt.GET("/anticipated", cache.Cache(store, DefaultCacheExpiration), TraktMostAnticipatedShows)
+			trakt.GET("/history", cache.Cache(store, DefaultCacheExpiration), TraktHistoryShows)
 			trakt.GET("/progress", cache.Cache(store, DefaultCacheExpiration), TraktProgressShows)
 
 			lists := trakt.Group("/lists")

--- a/api/routes.go
+++ b/api/routes.go
@@ -141,6 +141,7 @@ func Routes(btService *bittorrent.BTService) *gin.Engine {
 			trakt.GET("/watched", cache.Cache(store, DefaultCacheExpiration), TraktMostWatchedShows)
 			trakt.GET("/collected", cache.Cache(store, DefaultCacheExpiration), TraktMostCollectedShows)
 			trakt.GET("/anticipated", cache.Cache(store, DefaultCacheExpiration), TraktMostAnticipatedShows)
+			trakt.GET("/progress", cache.Cache(store, DefaultCacheExpiration), TraktProgressShows)
 
 			lists := trakt.Group("/lists")
 			{

--- a/api/routes.go
+++ b/api/routes.go
@@ -141,8 +141,8 @@ func Routes(btService *bittorrent.BTService) *gin.Engine {
 			trakt.GET("/watched", cache.Cache(store, DefaultCacheExpiration), TraktMostWatchedShows)
 			trakt.GET("/collected", cache.Cache(store, DefaultCacheExpiration), TraktMostCollectedShows)
 			trakt.GET("/anticipated", cache.Cache(store, DefaultCacheExpiration), TraktMostAnticipatedShows)
-			trakt.GET("/history", cache.Cache(store, DefaultCacheExpiration), TraktHistoryShows)
-			trakt.GET("/progress", cache.Cache(store, DefaultCacheExpiration), TraktProgressShows)
+			trakt.GET("/history", cache.Cache(store, RecentCacheExpiration), TraktHistoryShows)
+			trakt.GET("/progress", TraktProgressShows)
 
 			lists := trakt.Group("/lists")
 			{

--- a/api/shows.go
+++ b/api/shows.go
@@ -84,8 +84,8 @@ func TVTrakt(ctx *gin.Context) {
 		{Label: "LOCALIZE[30248]", Path: UrlForXBMC("/shows/trakt/watched"), Thumbnail: config.AddonResource("img", "most_watched.png")},
 		{Label: "LOCALIZE[30249]", Path: UrlForXBMC("/shows/trakt/collected"), Thumbnail: config.AddonResource("img", "most_collected.png")},
 		{Label: "LOCALIZE[30250]", Path: UrlForXBMC("/shows/trakt/anticipated"), Thumbnail: config.AddonResource("img", "most_anticipated.png")},
-		{Label: "HISTORY", Path: UrlForXBMC("/shows/trakt/history"), Thumbnail: config.AddonResource("img", "trakt.png")},
-		{Label: "PROGRESS", Path: UrlForXBMC("/shows/trakt/progress"), Thumbnail: config.AddonResource("img", "trakt.png")},
+		{Label: "My shows", Path: UrlForXBMC("/shows/trakt/history"), Thumbnail: config.AddonResource("img", "trakt.png")},
+		{Label: "My next episodes", Path: UrlForXBMC("/shows/trakt/progress"), Thumbnail: config.AddonResource("img", "trakt.png")},
 
 	}
 	ctx.JSON(200, xbmc.NewView("menus_tvshows", items))

--- a/api/shows.go
+++ b/api/shows.go
@@ -84,6 +84,7 @@ func TVTrakt(ctx *gin.Context) {
 		{Label: "LOCALIZE[30248]", Path: UrlForXBMC("/shows/trakt/watched"), Thumbnail: config.AddonResource("img", "most_watched.png")},
 		{Label: "LOCALIZE[30249]", Path: UrlForXBMC("/shows/trakt/collected"), Thumbnail: config.AddonResource("img", "most_collected.png")},
 		{Label: "LOCALIZE[30250]", Path: UrlForXBMC("/shows/trakt/anticipated"), Thumbnail: config.AddonResource("img", "most_anticipated.png")},
+		{Label: "PROGRESS", Path: UrlForXBMC("/shows/trakt/progress"), Thumbnail: config.AddonResource("img", "most_anticipated.png")},
 	}
 	ctx.JSON(200, xbmc.NewView("menus_tvshows", items))
 }

--- a/api/shows.go
+++ b/api/shows.go
@@ -84,7 +84,9 @@ func TVTrakt(ctx *gin.Context) {
 		{Label: "LOCALIZE[30248]", Path: UrlForXBMC("/shows/trakt/watched"), Thumbnail: config.AddonResource("img", "most_watched.png")},
 		{Label: "LOCALIZE[30249]", Path: UrlForXBMC("/shows/trakt/collected"), Thumbnail: config.AddonResource("img", "most_collected.png")},
 		{Label: "LOCALIZE[30250]", Path: UrlForXBMC("/shows/trakt/anticipated"), Thumbnail: config.AddonResource("img", "most_anticipated.png")},
-		{Label: "PROGRESS", Path: UrlForXBMC("/shows/trakt/progress"), Thumbnail: config.AddonResource("img", "most_anticipated.png")},
+		{Label: "HISTORY", Path: UrlForXBMC("/shows/trakt/history"), Thumbnail: config.AddonResource("img", "trakt.png")},
+		{Label: "PROGRESS", Path: UrlForXBMC("/shows/trakt/progress"), Thumbnail: config.AddonResource("img", "trakt.png")},
+
 	}
 	ctx.JSON(200, xbmc.NewView("menus_tvshows", items))
 }

--- a/api/trakt.go
+++ b/api/trakt.go
@@ -720,6 +720,14 @@ func TraktAllReleases(ctx *gin.Context) {
 	renderCalendarMovies(ctx, movies, total, page)
 }
 
+func TraktProgressShows(ctx *gin.Context) {
+	shows, err := trakt.ProgressShows()
+	if err != nil {
+		xbmc.Notify("Quasar", err.Error(), config.AddonIcon())
+	}
+	renderTraktShows(ctx, shows, -1, 0)
+}
+
 func renderCalendarMovies(ctx *gin.Context, movies []*trakt.CalendarMovie, total int, page int) {
 	hasNextPage := 0
 	if page > 0 {

--- a/api/trakt.go
+++ b/api/trakt.go
@@ -720,6 +720,14 @@ func TraktAllReleases(ctx *gin.Context) {
 	renderCalendarMovies(ctx, movies, total, page)
 }
 
+func TraktHistoryShows(ctx *gin.Context) {
+	shows, err := trakt.WatchedShows()
+	if err != nil {
+		xbmc.Notify("Quasar", err.Error(), config.AddonIcon())
+	}
+	renderTraktShows(ctx, shows, -1, 0)
+}
+
 func TraktProgressShows(ctx *gin.Context) {
 	shows, err := trakt.WatchedProgressShows()
 	if err != nil {

--- a/bittorrent/player.go
+++ b/bittorrent/player.go
@@ -697,6 +697,10 @@ func (btp *BTPlayer) Close() {
 			btp.log.Info("Removing the torrent without deleting files...")
 			btp.bts.Session.GetHandle().RemoveTorrent(btp.torrentHandle, 0)
 		}
+
+		if btp.contentType == "episode" {
+			trakt.AddToWatchedHistory(btp.tmdbId)
+		}
 	}
 }
 

--- a/bittorrent/player.go
+++ b/bittorrent/player.go
@@ -699,7 +699,9 @@ func (btp *BTPlayer) Close() {
 		}
 
 		if btp.contentType == "episode" {
-			trakt.AddToWatchedHistory(btp.showId, btp.season, btp.episode)
+			trakt.AddEpisodeToWatchedHistory(btp.showId, btp.season, btp.episode)
+		} else if btp.contentType == "movie" {
+			trakt.AddMovieToWatchedHistory(btp.tmdbId)
 		}
 	}
 }

--- a/bittorrent/player.go
+++ b/bittorrent/player.go
@@ -699,7 +699,7 @@ func (btp *BTPlayer) Close() {
 		}
 
 		if btp.contentType == "episode" {
-			trakt.AddToWatchedHistory(btp.tmdbId)
+			trakt.AddToWatchedHistory(btp.showId, btp.season, btp.episode)
 		}
 	}
 }

--- a/bittorrent/player.go
+++ b/bittorrent/player.go
@@ -1,28 +1,28 @@
 package bittorrent
 
 import (
-	"os"
-	"fmt"
-	"math"
-	"sort"
-	"sync"
-	"time"
 	"bufio"
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
-	"os/exec"
-	"io/ioutil"
-	"encoding/hex"
-	"path/filepath"
+	"sync"
+	"time"
 
-	"github.com/op/go-logging"
-	"github.com/dustin/go-humanize"
-	"github.com/scakemyer/libtorrent-go"
+	humanize "github.com/dustin/go-humanize"
+	logging "github.com/op/go-logging"
+	libtorrent "github.com/scakemyer/libtorrent-go"
 	"github.com/scakemyer/quasar/broadcast"
-	"github.com/scakemyer/quasar/diskusage"
 	"github.com/scakemyer/quasar/config"
+	"github.com/scakemyer/quasar/diskusage"
 	"github.com/scakemyer/quasar/trakt"
 	"github.com/scakemyer/quasar/xbmc"
 	"github.com/zeebo/bencode"
@@ -87,23 +87,24 @@ type BTPlayer struct {
 }
 
 type BTPlayerParams struct {
-	URI          string
-	FileIndex    int
-	ResumeIndex  int
-	FromLibrary  bool
-	ContentType  string
-	TMDBId       int
-	ShowID       int
-	Season       int
-	Episode      int
+	URI         string
+	FileIndex   int
+	ResumeIndex int
+	FromLibrary bool
+	ContentType string
+	TMDBId      int
+	ShowID      int
+	Season      int
+	Episode     int
 }
 
 type candidateFile struct {
-	Index     int
-	Filename  string
+	Index    int
+	Filename string
 }
 
 type byFilename []*candidateFile
+
 func (a byFilename) Len() int           { return len(a) }
 func (a byFilename) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a byFilename) Less(i, j int) bool { return a[i].Filename < a[j].Filename }
@@ -476,12 +477,12 @@ func (btp *BTPlayer) onMetadataReceived() {
 	for _ = 0; curPiece < startPiece; curPiece++ {
 		piecesPriorities.Add(0)
 	}
-	for _ = 0; curPiece < startPiece + startBufferPieces; curPiece++ { // get this part
+	for _ = 0; curPiece < startPiece+startBufferPieces; curPiece++ { // get this part
 		piecesPriorities.Add(7)
 		btp.bufferPiecesProgress[curPiece] = 0
 		btp.torrentHandle.SetPieceDeadline(curPiece, 0, 0)
 	}
-	for _ = 0; curPiece < endPiece - endBufferPieces; curPiece++ {
+	for _ = 0; curPiece < endPiece-endBufferPieces; curPiece++ {
 		piecesPriorities.Add(1)
 	}
 	for _ = 0; curPiece <= endPiece; curPiece++ { // get this part
@@ -497,7 +498,7 @@ func (btp *BTPlayer) onMetadataReceived() {
 }
 
 func (btp *BTPlayer) statusStrings(progress float64, status libtorrent.TorrentStatus) (string, string, string) {
-	line1 := fmt.Sprintf("%s (%.2f%%)", StatusStrings[int(status.GetState())], progress * 100)
+	line1 := fmt.Sprintf("%s (%.2f%%)", StatusStrings[int(status.GetState())], progress*100)
 	if btp.torrentInfo != nil && btp.torrentInfo.Swigcptr() != 0 {
 		var totalSize int64
 		if btp.fileSize > 0 && !btp.isRarArchive {
@@ -509,11 +510,11 @@ func (btp *BTPlayer) statusStrings(progress float64, status libtorrent.TorrentSt
 	}
 	seeders := status.GetNumSeeds()
 	line2 := fmt.Sprintf("D:%.0fkB/s U:%.0fkB/s S:%d/%d P:%d/%d",
-		float64(status.GetDownloadRate()) / 1024,
-		float64(status.GetUploadRate()) / 1024,
+		float64(status.GetDownloadRate())/1024,
+		float64(status.GetUploadRate())/1024,
 		seeders,
 		status.GetNumComplete(),
-		status.GetNumPeers() - seeders,
+		status.GetNumPeers()-seeders,
 		status.GetNumIncomplete(),
 	)
 	line3 := ""
@@ -558,7 +559,7 @@ func (btp *BTPlayer) chooseFile() (int, error) {
 
 		fileName := filepath.Base(files.FilePath(i))
 		re := regexp.MustCompile("(?i).*\\.rar")
-		if re.MatchString(fileName) && size > 10 * 1024 * 1024 {
+		if re.MatchString(fileName) && size > 10*1024*1024 {
 			btp.isRarArchive = true
 			if !xbmc.DialogConfirm("Quasar", "LOCALIZE[30303]") {
 				btp.notEnoughSpace = true
@@ -620,16 +621,16 @@ func (btp *BTPlayer) chooseFile() (int, error) {
 	return biggestFile, nil
 }
 
-func (btp *BTPlayer) findSubtitlesFile() (int) {
+func (btp *BTPlayer) findSubtitlesFile() int {
 	extension := filepath.Ext(btp.fileName)
-	chosenName := btp.fileName[0:len(btp.fileName)-len(extension)]
+	chosenName := btp.fileName[0 : len(btp.fileName)-len(extension)]
 	srtFileName := chosenName + ".srt"
 
 	numFiles := btp.torrentInfo.NumFiles()
 	files := btp.torrentInfo.Files()
 
-	lastMatched := 0;
-	countMatched := 0;
+	lastMatched := 0
+	countMatched := 0
 
 	for i := 0; i < numFiles; i++ {
 		fileName := files.FilePath(i)
@@ -698,10 +699,13 @@ func (btp *BTPlayer) Close() {
 			btp.bts.Session.GetHandle().RemoveTorrent(btp.torrentHandle, 0)
 		}
 
-		if btp.contentType == "episode" {
-			trakt.AddEpisodeToWatchedHistory(btp.showId, btp.season, btp.episode)
-		} else if btp.contentType == "movie" {
-			trakt.AddMovieToWatchedHistory(btp.tmdbId)
+		progress := WatchedTime / VideoDuration * 100
+		if progress >= 80 {
+			if btp.contentType == "episode" {
+				trakt.AddEpisodeToWatchedHistory(btp.showId, btp.season, btp.episode)
+			} else if btp.contentType == "movie" {
+				trakt.AddMovieToWatchedHistory(btp.tmdbId)
+			}
 		}
 	}
 }
@@ -785,7 +789,7 @@ func (btp *BTPlayer) bufferDialog() {
 			if int(status.GetState()) == 1 || btp.isRarArchive {
 				progress := float64(status.GetProgress())
 				line1, line2, line3 := btp.statusStrings(progress, status)
-				btp.dialogProgress.Update(int(progress * 100.0), line1, line2, line3)
+				btp.dialogProgress.Update(int(progress*100.0), line1, line2, line3)
 
 				if btp.isRarArchive && progress >= 1 {
 					archivePath := filepath.Join(btp.bts.config.DownloadPath, btp.torrentInfo.Files().FilePath(btp.chosenFile))
@@ -856,7 +860,7 @@ func (btp *BTPlayer) bufferDialog() {
 				}
 				btp.bufferPiecesProgressLock.Unlock()
 				line1, line2, line3 := btp.statusStrings(bufferProgress, status)
-				btp.dialogProgress.Update(int(bufferProgress * 100.0), line1, line2, line3)
+				btp.dialogProgress.Update(int(bufferProgress*100.0), line1, line2, line3)
 				if bufferProgress >= 1 {
 					btp.setRateLimiting(true)
 					btp.bufferEvents.Signal()
@@ -948,7 +952,7 @@ playbackWaitLoop:
 		}
 		select {
 		case <-playbackTimeout:
-			btp.log.Warningf("Playback was unable to start after %d seconds. Aborting...", playbackMaxWait / time.Second)
+			btp.log.Warningf("Playback was unable to start after %d seconds. Aborting...", playbackMaxWait/time.Second)
 			btp.bufferEvents.Broadcast(errors.New("Playback was unable to start before timeout."))
 			return
 		case <-oneSecond.C:

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -575,7 +575,6 @@ func WatchedProgressShows() (shows []*ProgressShow, err error) {
 			return shows, err
 		}
 		for _, show := range watchedShows {
-			log.Error("Looping the show: ", show.Show.IDs.Slug)
 			endPoint := fmt.Sprintf("shows/%s/progress/watched", show.Show.IDs.Slug)
 
 			resp, err := GetWithAuth(endPoint, params)
@@ -586,23 +585,23 @@ func WatchedProgressShows() (shows []*ProgressShow, err error) {
 				log.Error(err)
 				return shows, errors.New(fmt.Sprintf("Bad status getting Trakt watched shows: %d", resp.Status()))
 			}
-			log.Error("Respuesta del api de trakt : ", resp)
 			var watchedProgressShow *WatchedProgressShow
 			if err := resp.Unmarshal(&watchedProgressShow); err != nil {
 				log.Warning(err)
 			}
 			
-			showItem := ProgressShow{
-				Show: watchedProgressShow.Show,
-				FirstAired: watchedProgressShow.NextEpisode.FirstAired,
-				Episode: &watchedProgressShow.NextEpisode,
-			}
+			if watchedProgressShow.NextEpisode.Number != 0 && watchedProgressShow.NextEpisode.Season != 0 {
+				showItem := ProgressShow{
+					Show: show.Show,
+					Episode: &watchedProgressShow.NextEpisode,
+				}
 
-			showListing = append(showListing, &showItem)
+				showListing = append(showListing, &showItem)
+			}
 		}
 
 		shows = showListing
-		//shows = setProgressShowsFanart(shows)
+		shows = setProgressShowsFanart(shows)
 		cacheStore.Set(key, shows, recentExpiration)
 	}	
 

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -601,7 +601,7 @@ func WatchedProgressShows() (shows []*ProgressShow, err error) {
 
 		shows = showListing
 		shows = setProgressShowsFanart(shows)
-		cacheStore.Set(key, shows, recentExpiration)
+		cacheStore.Set(key, shows, 1 * time.Minute)
 	}	
 
 	return

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path"
 	"time"
-  "errors"
+  	"errors"
 	"strconv"
 	"strings"
 	"math/rand"

--- a/trakt/shows.go
+++ b/trakt/shows.go
@@ -554,7 +554,6 @@ func WatchedShows() (shows []*Shows, err error) {
 }
 
 func WatchedProgressShows() (shows []*ProgressShow, err error) {
-	log.Error("I AM IN TRAKT WatchedProgressShows")
 	if err := Authorized(); err != nil {
 		return shows, err
 	}

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -167,6 +167,12 @@ type WatchlistEpisode struct {
 	Show     *Object  `json:"show"`
 }
 
+type WatchedShow struct {
+	Plays			int `json:"plays"`
+	LastWatchedAt	string `json:"last_watched_at"`
+	Show 			*Show `json:"show"`
+}
+
 type CollectionMovie struct {
 	CollectedAt string `json:"collected_at"`
 	Movie       *Movie `json:"movie"`

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -180,11 +180,9 @@ type WatchedProgressShow struct {
 	Seasons			[]*Season	`json:"seasons"`
 	HiddenSeasons	[]*Season	`json:"hidden_seasons"`
 	NextEpisode		Episode		`json:"next_episode"`
-	Show			*Show		`json:"show"`
 }
 
 type ProgressShow struct {
-	FirstAired  string   `json:"first_aired"`
 	Episode     *Episode `json:"episode"`
 	Show        *Show    `json:"show"`
 }

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -733,20 +733,39 @@ func Scrobble(action string, contentType string, tmdbId int, watched float64, ru
 	}
 }
 
-func AddToWatchedHistory(showId, season, episode int) {
+func AddEpisodeToWatchedHistory(showId, season, episode int) {
 	if err := Authorized(); err != nil {
 		return
 	}
 
 	endPoint := "sync/history"
-	payload := fmt.Sprintf(`{"shows": [{ "ids": {"tmdb": %d}, "seasons": [{ "number": %d, "episodes": [{"watched_at": %s, "number": %d }]}]}]}`, showId, season, time.Now().Format("20060102-15:04:05.000"), episode)
-	log.Noticef("Calling endpoint: ", endpoint, "\npayload: ", payload)
+	payload := fmt.Sprintf(`{"shows": [{ "ids": {"tmdb": %d}, "seasons": [{ "number": %d, "episodes": [{"watched_at": "%s", "number": %d }]}]}]}`, showId, season, time.Now().Format("20060102-15:04:05.000"), episode)
+	log.Noticef("Calling endpoint: ", endPoint, "\npayload: ", payload)
 	resp, err := Post(endPoint, bytes.NewBufferString(payload))
-	log.Noticef("resp: %s", string(resp))
+	log.Noticef(resp.RawText())
 	if err != nil {
 		log.Error(err.Error())
-		xbmc.Notify("Quasar", "AddToWatchedHistory failed, check your logs.", config.AddonIcon())
+		xbmc.Notify("Quasar", "AddEpisodeToWatchedHistory failed, check your logs.", config.AddonIcon())
 	} else if resp.Status() != 201 {
-		log.Errorf("Failed in AddToWatchedHistory to sync/history showId %d season %d episode %d", showId, season, episode)
+		log.Errorf("Failed in AddEpisodeToWatchedHistory to sync/history showId %d season %d episode %d", showId, season, episode)
 	}
 }
+
+func AddMovieToWatchedHistory(movie int) {
+	if err := Authorized(); err != nil {
+		return
+	}
+
+	endPoint := "sync/history"
+	payload := fmt.Sprintf(`{"movies": [{ "watched_at": "%s", "ids": {"tmdb": %d }}]}`, time.Now().Format("20060102-15:04:05.000"), movie)
+	log.Noticef("Calling endpoint: ", endPoint, "\npayload: ", payload)
+	resp, err := Post(endPoint, bytes.NewBufferString(payload))
+	log.Noticef(resp.RawText())
+	if err != nil {
+		log.Error(err.Error())
+		xbmc.Notify("Quasar", "AddMovieToWatchedHistory failed, check your logs.", config.AddonIcon())
+	} else if resp.Status() != 201 {
+		log.Errorf("Failed in AddMovieToWatchedHistory to sync/history movie %d", movie)
+	}
+}
+

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -173,6 +173,15 @@ type WatchedShow struct {
 	Show 			*Show `json:"show"`
 }
 
+type WatchedProgressShow struct {
+	Aired			int `json:"aired"`
+	Completed		int `json:"completed"`
+	LastWatchedAt	string `json:"last_watched_at"`
+	Seasons			[]*Season `json:"seasons"`
+	HiddenSeasons	[]*Season `json:"hidden_seasons"`
+	NextEpisode		Episode `json:"next_episode"`
+}
+
 type CollectionMovie struct {
 	CollectedAt string `json:"collected_at"`
 	Movie       *Movie `json:"movie"`

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -168,18 +168,25 @@ type WatchlistEpisode struct {
 }
 
 type WatchedShow struct {
-	Plays			int `json:"plays"`
-	LastWatchedAt	string `json:"last_watched_at"`
-	Show 			*Show `json:"show"`
+	Plays			int		`json:"plays"`
+	LastWatchedAt	string	`json:"last_watched_at"`
+	Show 			*Show	`json:"show"`
 }
 
 type WatchedProgressShow struct {
-	Aired			int `json:"aired"`
-	Completed		int `json:"completed"`
-	LastWatchedAt	string `json:"last_watched_at"`
-	Seasons			[]*Season `json:"seasons"`
-	HiddenSeasons	[]*Season `json:"hidden_seasons"`
-	NextEpisode		Episode `json:"next_episode"`
+	Aired			int			`json:"aired"`
+	Completed		int			`json:"completed"`
+	LastWatchedAt	string		`json:"last_watched_at"`
+	Seasons			[]*Season	`json:"seasons"`
+	HiddenSeasons	[]*Season	`json:"hidden_seasons"`
+	NextEpisode		Episode		`json:"next_episode"`
+	Show			*Show		`json:"show"`
+}
+
+type ProgressShow struct {
+	FirstAired  string   `json:"first_aired"`
+	Episode     *Episode `json:"episode"`
+	Show        *Show    `json:"show"`
 }
 
 type CollectionMovie struct {

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -733,22 +733,20 @@ func Scrobble(action string, contentType string, tmdbId int, watched float64, ru
 	}
 }
 
-func AddToWatchedHistory(tmdbId int) {
+func AddToWatchedHistory(showId, season, episode int) {
 	if err := Authorized(); err != nil {
 		return
 	}
 
 	endPoint := "sync/history"
-	payload := fmt.Sprintf(`{"episodes": [{"watched_at": %s, "ids": {"tmdb": %d}}]}`, time.Now().Format("20060102-15:04:05.000"), tmdbId)
+	payload := fmt.Sprintf(`{"shows": [{ "ids": {"tmdb": %d}, "seasons": [{ "number": %d, "episodes": [{"watched_at": %s, "number": %d }]}]}]}`, showId, season, time.Now().Format("20060102-15:04:05.000"), episode)
+	log.Noticef("Calling endpoint: ", endpoint, "\npayload: ", payload)
 	resp, err := Post(endPoint, bytes.NewBufferString(payload))
+	log.Noticef("resp: %s", string(resp))
 	if err != nil {
 		log.Error(err.Error())
 		xbmc.Notify("Quasar", "AddToWatchedHistory failed, check your logs.", config.AddonIcon())
 	} else if resp.Status() != 201 {
-		log.Errorf("Failed to sync/history episodes tmdbId #%d", tmdbId)
+		log.Errorf("Failed in AddToWatchedHistory to sync/history showId %d season %d episode %d", showId, season, episode)
 	}
 }
-
-
-
-

--- a/trakt/trakt.go
+++ b/trakt/trakt.go
@@ -732,3 +732,23 @@ func Scrobble(action string, contentType string, tmdbId int, watched float64, ru
 		log.Errorf("Failed to scrobble %s #%d to %s at %f: %d", contentType, tmdbId, action, progress, resp.Status())
 	}
 }
+
+func AddToWatchedHistory(tmdbId int) {
+	if err := Authorized(); err != nil {
+		return
+	}
+
+	endPoint := "sync/history"
+	payload := fmt.Sprintf(`{"episodes": [{"watched_at": %s, "ids": {"tmdb": %d}}]}`, time.Now().Format("20060102-15:04:05.000"), tmdbId)
+	resp, err := Post(endPoint, bytes.NewBufferString(payload))
+	if err != nil {
+		log.Error(err.Error())
+		xbmc.Notify("Quasar", "AddToWatchedHistory failed, check your logs.", config.AddonIcon())
+	} else if resp.Status() != 201 {
+		log.Errorf("Failed to sync/history episodes tmdbId #%d", tmdbId)
+	}
+}
+
+
+
+


### PR DESCRIPTION
I've added two new categories under Shows/Trakt section.

- My Shows: All TV Shows that the users have been watched in Trakt
- My Next Episodes: The next episodes of TV Shows that the users are watching in Trakt

scakemyer/plugin.video.quasar#580
scakemyer/plugin.video.quasar#607

TODO: update the resources/languages of plugin to change the "My shows" and "My next episodes" label for the corresponding LOCALIZE

I added new changes for when a user finishes to watch a movie or an episode, is marked automatically as watched in Trakt